### PR TITLE
fix(créer_tag): correction de la récupération du dernier tag

### DIFF
--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Get Last Tag
         id: lasttag
         run: |
-          LAST_TAG=$(git describe --tags `git rev-list --tags --max-count=1` 2>/dev/null || echo "v1.0.0")
+          LAST_TAG=$(git describe --tags `git rev-list --tags --max-count=1` 2>/dev/null || echo "0.0.0")
           echo "::set-output name=tag::$LAST_TAG"
 
       - name: Extract PR Titles


### PR DESCRIPTION
La modification permet de corriger la récupération du dernier tag en cas d'absence de tag existant.