### PR TITLE
fix(create_tag): Correction de la récupération des titres des PRs
fix(create_tag): Correction de la récupération des titres des PRs (#22)

### DIFF
--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Get Last Tag
         id: lasttag
         run: |
-          LAST_TAG=$(git describe --tags `git rev-list --tags --max-count=1` 2>/dev/null || echo "v1.0.0")
+          LAST_TAG=$(git describe --tags `git rev-list --tags --max-count=1` 2>/dev/null || echo "0.0.0")
           echo "::set-output name=tag::$LAST_TAG"
 
       - name: Extract PR Titles

--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -21,7 +21,11 @@ jobs:
       - name: Extract PR Titles
         id: pr-titles
         run: |
-          PR_TITLES=$(git log $(echo ${{ steps.lasttag.outputs.tag }})..HEAD --pretty=format:"%s")
+          if [[ "${{ steps.lasttag.outputs.tag }}" == "0.0.0" ]]; then
+            PR_TITLES=$(git log --pretty=format:"%s")
+          else
+            PR_TITLES=$(git log $(echo ${{ steps.lasttag.outputs.tag }})..HEAD --pretty=format:"%s")
+          fi
           echo "::set-output name=titles::$PR_TITLES"
 
       - name: Determine Version Increment


### PR DESCRIPTION
Correction d'un problème dans le workflow de création de tag où les titres des PRs n'étaient pas correctement récupérés lorsque le dernier tag était "0.0.0".